### PR TITLE
carriageReturn also interpreted at start of line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *~
 *.log
 node_modules
+.idea
+*.iml

--- a/lib/index.js
+++ b/lib/index.js
@@ -269,6 +269,7 @@ module.exports = class Anser {
         if (options && options.json) {
             let first = self.processChunkJson("");
             first.content = first_chunk;
+            first.clearLine = options.clearLine;
             color_chunks.unshift(first);
             if (options.remove_empty) {
                 color_chunks = color_chunks.filter(c => !c.isEmpty());

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -536,5 +536,12 @@ describe("Anser", () => {
             output[0].clearLine.should.eql(false);
             output[1].clearLine.should.eql(false);
         });
+        it("should convert ansi with carriageReturn at start of line to json with positive clearLine", () => {
+            const start = "\r  zc = 9  zm = 9  zs = 3  f = 4";
+            const output = Anser.ansiToJson(start, {
+                remove_empty: true
+            });
+            output[0].clearLine.should.eql(true);
+        });
     });
 });


### PR DESCRIPTION
@IonicaBizau I just noticed that there is one case missing, when `\r` occurs at start of line.
That is how e.g. `optipng` does it. Also now `clearLine` is always either true or false and never `undefined`.

Can you merge that too? I also added a test.

#18 