### PR TITLE
Revert special treatment of grey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -366,10 +366,8 @@ class Anser {
 
             if (isNaN(num) || num === 0) {
                 self.fg = self.bg = self.decoration = null;
-                self.bright = 0;
             } else if (num === 1) {
-                self.bright = 1;
-                self.decoration = "bright";
+                self.decoration = "bold";
             } else if (num === 2) {
                 self.decoration = "dim";
             // Enable code 2 to get string
@@ -390,12 +388,16 @@ class Anser {
                 self.fg = null;
             } else if (num == 49) {
                 self.bg = null;
+            // Foreground color
             } else if ((num >= 30) && (num < 38)) {
-                self.fg = ANSI_COLORS[self.bright][(num % 10)][key];
+                self.fg = ANSI_COLORS[0][(num % 10)][key];
+            // Foreground bright color
             } else if ((num >= 90) && (num < 98)) {
                 self.fg = ANSI_COLORS[1][(num % 10)][key];
+            // Background color
             } else if ((num >= 40) && (num < 48)) {
                 self.bg = ANSI_COLORS[0][(num % 10)][key];
+            // Background bright color
             } else if ((num >= 100) && (num < 108)) {
                 self.bg = ANSI_COLORS[1][(num % 10)][key];
             } else if (num === 38 || num === 48) { // extend color (38=fg, 48=bg)
@@ -538,14 +540,17 @@ class Anser {
         if (jsonChunk.decoration) {
             if (use_classes) {
                 classes.push("ansi-" + jsonChunk.decoration);
-            } else if (jsonChunk.decoration === "hidden") {
-                styles.push("visibility:hidden");
+            } else if (jsonChunk.decoration === "bold") {
+                styles.push("font-weight:bold");
             } else if (jsonChunk.decoration === "dim") {
                 styles.push("opacity:0.5");
+            } else if (jsonChunk.decoration === "italic") {
+                styles.push("font-style:italic");
+            // underline and blink are treated bellow
             } else if (jsonChunk.decoration === "reverse") {
                 styles.push("filter:invert(100%)");
-            } else if (jsonChunk.decoration === "bright") {
-                styles.push("text-decoration:bold");
+            } else if (jsonChunk.decoration === "hidden") {
+                styles.push("visibility:hidden");
             } else if (jsonChunk.decoration === "strikethrough") {
                 styles.push("text-decoration:line-through");
             } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -392,10 +392,7 @@ class Anser {
                 self.bg = null;
             } else if ((num >= 30) && (num < 38)) {
                 self.fg = ANSI_COLORS[self.bright][(num % 10)][key];
-            // Enable code 90 to get grey
-            } else if ((num == 90)) {
-                  self.fg = "grey";
-            } else if ((num > 90) && (num < 98)) {
+            } else if ((num >= 90) && (num < 98)) {
                 self.fg = ANSI_COLORS[1][(num % 10)][key];
             } else if ((num >= 40) && (num < 48)) {
                 self.bg = ANSI_COLORS[0][(num % 10)][key];
@@ -522,15 +519,7 @@ class Anser {
                     jsonChunk.fg_truecolor = null;
                 }
             } else {
-                // Split fg color on array
-                let colors = jsonChunk.fg.split(",").map(String);
-                // Color has one field
-                if (colors.length == 1) {
-                    styles.push("color:" + jsonChunk.fg + "");
-                }
-                else {
-                    styles.push("color:rgb(" + jsonChunk.fg + ")");
-                }
+                styles.push("color:rgb(" + jsonChunk.fg + ")");
             }
         }
 
@@ -542,46 +531,25 @@ class Anser {
                     jsonChunk.bg_truecolor = null;
                 }
             } else {
-              let colors = jsonChunk.bg.split(",").map(String);
-              if (colors.length == 1) {
-                  styles.push("color:" + jsonChunk.bg + "");
-              }
-              else {
-                styles.push("background-color:rgb(" + jsonChunk.bg + ")");
-              }
+              styles.push("background-color:rgb(" + jsonChunk.bg + ")");
             }
         }
 
         if (jsonChunk.decoration) {
             if (use_classes) {
                 classes.push("ansi-" + jsonChunk.decoration);
-            } else if (jsonChunk.decoration === "bright"
-            || jsonChunk.decoration === "underline"
-            || jsonChunk.decoration === "blink"
-            || jsonChunk.decoration === "italic"
-            || jsonChunk.decoration === "hidden"
-            || jsonChunk.decoration === "dim"
-            || jsonChunk.decoration === "reverse"
-            || jsonChunk.decoration === "strikethrough"
-          ) {
-            if(jsonChunk.decoration === "hidden") {
+            } else if (jsonChunk.decoration === "hidden") {
                 styles.push("visibility:hidden");
-            }
-            else if(jsonChunk.decoration === "dim") {
+            } else if (jsonChunk.decoration === "dim") {
                 styles.push("opacity:0.5");
-            }
-            else if(jsonChunk.decoration === "reverse") {
+            } else if (jsonChunk.decoration === "reverse") {
                 styles.push("filter:invert(100%)");
-            }
-            else if(jsonChunk.decoration === "bright") {
+            } else if (jsonChunk.decoration === "bright") {
                 styles.push("text-decoration:bold");
-            }
-            else if(jsonChunk.decoration === "strikethrough") {
+            } else if (jsonChunk.decoration === "strikethrough") {
                 styles.push("text-decoration:line-through");
-            }
-            else{
+            } else {
                 styles.push("text-decoration:" + jsonChunk.decoration);
-                }
             }
         }
 

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -127,11 +127,11 @@ describe("Anser", () => {
                 const attr = 1;
                 const fg = 32;
                 const start = "\x1B[" + attr + ";" + fg + "m " + attr + ";" + fg + " \x1B[0m";
-                const expected = "<span style=\"color:rgb(0, 255, 0);text-decoration:bold\"> " + attr + ";" + fg + " </span>";
+                const expected = "<span style=\"color:rgb(0, 187, 0);font-weight:bold\"> " + attr + ";" + fg + " </span>";
                 const l = Anser.ansiToHtml(start);
                 l.should.eql(expected);
             });
-            it("should transform a bold-foreground to html", () => {
+            it("should transform a bright-foreground to html", () => {
                 const fg = 92;
                 const start = "\x1B[" + fg + "m " + fg + " \x1B[0m";
                 const expected = "<span style=\"color:rgb(0, 255, 0)\"> " + fg + " </span>";
@@ -143,11 +143,11 @@ describe("Anser", () => {
                 const fg = 33;
                 const bg = 42;
                 const start = "\x1B[" + attr + ";" + bg + ";" + fg + "m " + attr + ";" + bg + ";" + fg + " \x1B[0m";
-                const expected = "<span style=\"color:rgb(255, 255, 85);background-color:rgb(0, 187, 0);text-decoration:bold\"> " + attr + ";" + bg + ";" + fg + " </span>";
+                const expected = "<span style=\"color:rgb(187, 187, 0);background-color:rgb(0, 187, 0);font-weight:bold\"> " + attr + ";" + bg + ";" + fg + " </span>";
                 const l = Anser.ansiToHtml(start);
                 l.should.eql(expected);
             });
-            it("should transform a bold-background;foreground to html", () => {
+            it("should transform a bright-background;foreground to html", () => {
                 const fg = 33;
                 const bg = 102;
                 const start = "\x1B[" + bg + ";" + fg + "m " + bg + ";" + fg + " \x1B[0m";
@@ -227,13 +227,13 @@ describe("Anser", () => {
                 });
                 it("combination of bold and palette", () => {
                     const start = "\x1B[1;38;5;171m" + "foo" + "\x1B[0m";
-                    const expected = "<span style=\"color:rgb(215, 95, 255);text-decoration:bold\">foo</span>";
+                    const expected = "<span style=\"color:rgb(215, 95, 255);font-weight:bold\">foo</span>";
                     const l = Anser.ansiToHtml(start);
                     l.should.eql(expected);
                 });
                 it("combination of palette and bold", () => {
                     const start = "\x1B[38;5;171;1m" + "foo" + "\x1B[0m";
-                    const expected = "<span style=\"color:rgb(215, 95, 255);text-decoration:bold\">foo</span>";
+                    const expected = "<span style=\"color:rgb(215, 95, 255);font-weight:bold\">foo</span>";
                     const l = Anser.ansiToHtml(start);
                     l.should.eql(expected);
                 });
@@ -287,7 +287,7 @@ describe("Anser", () => {
                 const attr = 1;
                 const fg = 32;
                 const start = "\x1B[" + attr + ";" + fg + "m " + attr + ";" + fg + " \x1B[0m";
-                const expected = "<span class=\"ansi-bright-green-fg ansi-bright\"> " + attr + ";" + fg + " </span>";
+                const expected = "<span class=\"ansi-green-fg ansi-bold\"> " + attr + ";" + fg + " </span>";
                 const l = Anser.ansiToHtml(start, {use_classes: true});
                 l.should.eql(expected);
             });
@@ -297,7 +297,7 @@ describe("Anser", () => {
                 const fg = 33;
                 const bg = 42;
                 const start = "\x1B[" + attr + ";" + bg + ";" + fg + "m " + attr + ";" + bg + ";" + fg + " \x1B[0m";
-                const expected = "<span class=\"ansi-bright-yellow-fg ansi-green-bg ansi-bright\"> " + attr + ";" + bg + ";" + fg + " </span>";
+                const expected = "<span class=\"ansi-yellow-fg ansi-green-bg ansi-bold\"> " + attr + ";" + bg + ";" + fg + " </span>";
                 const l = Anser.ansiToHtml(start, {use_classes: true});
                 l.should.eql(expected);
             });
@@ -357,14 +357,14 @@ describe("Anser", () => {
 
                 it("combination of bold and palette", () => {
                     const start = "\x1B[1;38;5;171m" + "foo" + "\x1B[0m";
-                    const expected = "<span class=\"ansi-palette-171-fg ansi-bright\">foo</span>";
+                    const expected = "<span class=\"ansi-palette-171-fg ansi-bold\">foo</span>";
                     const l = Anser.ansiToHtml(start, {use_classes: true});
                     l.should.eql(expected);
                 });
 
                 it("combination of palette and bold", () => {
                     const start = "\x1B[38;5;171;1m" + "foo" + "\x1B[0m";
-                    const expected = "<span class=\"ansi-palette-171-fg ansi-bright\">foo</span>";
+                    const expected = "<span class=\"ansi-palette-171-fg ansi-bold\">foo</span>";
                     const l = Anser.ansiToHtml(start, {use_classes: true});
                     l.should.eql(expected);
                 });
@@ -452,7 +452,7 @@ describe("Anser", () => {
             it("(italic)", () => {
                 const start = "foo\x1B[3mbar\x1B[0mbaz";
                 const l = Anser.ansiToHtml(start);
-                l.should.eql("foo<span style=\"text-decoration:italic\">bar</span>baz");
+                l.should.eql("foo<span style=\"font-style:italic\">bar</span>baz");
             });
             it("(cursor-up)", () => {
                 const start = "foo\x1B[1Abar";


### PR DESCRIPTION
I would like to revert the special `grey` treatment that was done in https://github.com/IonicaBizau/anser/pull/35.

Reasons:
- The previous PR was adding a `grey` class instead of `ansi-grey`. 
- I thought a bit about it and the previous naming was ok (`ansi-black-bright`).

Additionally:
- I've refactored the elseif chains to be more readable.
- Fixed incorrect CSS styles
- Removed the use of bright colors when text is bold.. this doesn't make much sense in the first place