### PR TITLE
Fix TypeScript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ console.log(Anser.ansiToJson(txt));
 ```
 
 
-When using **Typescript** you can do the following:
+When using **TypeScript** you can do the following:
 ```ts
-import Anser from 'anser'; // make sure to NOT use curly braces!
+import * as Anser from 'anser';
 const txt = "\u001b[38;5;196mHello\u001b[39m \u001b[48;5;226mWorld\u001b[49m";
 console.log(Anser.ansiToHtml(txt));
 // <span style="color:rgb(255, 0, 0)">Hello</span> <span style="background-color:rgb(255, 255, 0)">World</span>

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -16,15 +16,12 @@ export interface AnserOptions {
   use_classes?: boolean;
 }
 
-export default class Anser {
-  static ansiToJson(txt: string, options?: AnserOptions): AnserJsonEntry[];
+export function ansiToJson(txt: string, options?: AnserOptions): AnserJsonEntry[];
 
-  static ansiToHtml(txt: string, options?: AnserOptions): string;
+export function ansiToHtml(txt: string, options?: AnserOptions): string;
 
-  static ansiToText(txt: string, options?: AnserOptions): string;
+export function ansiToText(txt: string, options?: AnserOptions): string;
 
-  static escapeForHtml(txt: string): string;
+export function escapeForHtml(txt: string): string;
 
-  static linkify(txt: string): string;
-
-}
+export function linkify(txt: string): string;

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
       }
     ],
     "example": [
-      "When using **Typescript** you can do the following:",
+      "When using **TypeScript** you can do the following:",
       {
         "code": {
           "content": [
-            "import Anser from 'anser'; // make sure to NOT use curly braces!",
+            "import * as Anser from 'anser';",
             "const txt = \"\\u001b[38;5;196mHello\\u001b[39m \\u001b[48;5;226mWorld\\u001b[49m\";",
             "console.log(Anser.ansiToHtml(txt));",
             "// <span style=\"color:rgb(255, 0, 0)\">Hello</span> <span style=\"background-color:rgb(255, 255, 0)\">World</span>"


### PR DESCRIPTION
`module.exports = Anser` is imported via `import * as Anser from "anser"` in TypeScript. For `import Anser from "anser"` to work, you'd need to use `export default class Anser` in your JS (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#Using_the_default_export). Rather than change the export, I changed the typings to match the JS instead.