### PR TITLE
Adding support for multiple decorations per chunk and proper colors inverse

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for Anser
 // Project: https://github.com/IonicaBizau/anser
 
+type DecorationName = 'bold' | 'dim' | 'italic' | 'underline' | 'blink' | 'reverse' | 'hidden' | 'strikethrough';
+
 export interface AnserJsonEntry {
     /** The text. */
     content: string;
@@ -14,7 +16,10 @@ export interface AnserJsonEntry {
     bg_truecolor: string;
     /** `true` if a carriageReturn \r was fount at end of line. */
     clearLine: boolean;
-    decoration: null | 'bold' | 'dim' | 'italic' | 'underline' | 'blink' | 'reverse' | 'hidden' | 'strikethrough';
+    /** The decoration last declared before the text. */
+    decoration: null | DecorationName;
+    /** All decorations that apply to the text. */
+    decorations: Array<DecorationName>;
     /** `true` if the colors were processed, `false` otherwise. */
     was_processed: boolean;
     /** A function returning `true` if the content is empty, or `false` otherwise. */

--- a/lib/index.js
+++ b/lib/index.js
@@ -320,6 +320,7 @@ class Anser {
           , bg: null
           , fg_truecolor: null
           , bg_truecolor: null
+          , isInverted: false
           , clearLine: options.clearLine
           , decoration: null
           , decorations: []
@@ -493,18 +494,40 @@ class Anser {
     processChunk (text, options, markup) {
         options = options || {};
         let jsonChunk = this.processChunkJson(text, options, markup);
+        let use_classes = options.use_classes;
+
+        // "reverse" decoration reverses foreground and background colors
+        jsonChunk.decorations = jsonChunk.decorations
+            .filter((decoration) => {
+                if (decoration === "reverse") {
+                    // when reversing, missing colors are defaulted to black (bg) and white (fg)
+                    if (!jsonChunk.fg) {
+                      jsonChunk.fg = ANSI_COLORS[0][7][use_classes ? "class" : "color"];
+                    }
+                    if (!jsonChunk.bg) {
+                      jsonChunk.bg = ANSI_COLORS[0][0][use_classes ? "class" : "color"];
+                    }
+                    let tmpFg = jsonChunk.fg;
+                    jsonChunk.fg = jsonChunk.bg;
+                    jsonChunk.bg = tmpFg;
+                    let tmpFgTrue = jsonChunk.fg_truecolor;
+                    jsonChunk.fg_truecolor = jsonChunk.bg_truecolor;
+                    jsonChunk.bg_truecolor = tmpFgTrue;
+                    jsonChunk.isInverted = true;
+                    return false;
+                }
+                return true;
+            });
 
         if (options.json) { return jsonChunk; }
         if (jsonChunk.isEmpty()) { return ""; }
         if (!jsonChunk.was_processed) { return jsonChunk.content; }
 
-        let use_classes = options.use_classes;
-
         let colors = [];
         let decorations = [];
         let textDecorations = [];
-
         let data = {};
+
         let render_data = data => {
             let fragments = [];
             let key;
@@ -515,6 +538,10 @@ class Anser {
             }
             return fragments.length > 0 ? " " + fragments.join(" ") : "";
         };
+
+        if (jsonChunk.isInverted) {
+          data["ansi-is-inverted"] = "true";
+        }
 
         if (jsonChunk.fg) {
             if (use_classes) {
@@ -541,16 +568,18 @@ class Anser {
         }
 
         jsonChunk.decorations.forEach((decoration) => {
+            // use classes
             if (use_classes) {
                 decorations.push("ansi-" + decoration);
-            } else if (decoration === "bold") {
+                return;
+            }
+            // use styles            
+            if (decoration === "bold") {
                 decorations.push("font-weight:bold");
             } else if (decoration === "dim") {
                 decorations.push("opacity:0.5");
             } else if (decoration === "italic") {
                 decorations.push("font-style:italic");
-              } else if (decoration === "reverse") {
-                decorations.push("filter:invert(100%)");
             } else if (decoration === "hidden") {
                 decorations.push("visibility:hidden");
             } else if (decoration === "strikethrough") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -316,14 +316,15 @@ class Anser {
 
         let result = {
             content: text
-        , fg: null
-        , bg: null
-        , fg_truecolor: null
-        , bg_truecolor: null
-        , clearLine: options.clearLine
-        , decoration: null
-        , was_processed: false
-        , isEmpty: () => !result.content
+          , fg: null
+          , bg: null
+          , fg_truecolor: null
+          , bg_truecolor: null
+          , clearLine: options.clearLine
+          , decoration: null
+          , decorations: []
+          , was_processed: false
+          , isEmpty: () => !result.content
         };
 
         // Each "chunk" is the text after the CSI (ESC + "[") and before the next CSI/EOF.
@@ -358,32 +359,33 @@ class Anser {
 
         let self = this;
 
-        self.decoration = null;
+        self.decorations = self.decorations || [];
 
         while (nums.length > 0) {
             let num_str = nums.shift();
             let num = parseInt(num_str);
 
             if (isNaN(num) || num === 0) {
-                self.fg = self.bg = self.decoration = null;
+                self.fg = self.bg = null;
+                self.decorations = [];
             } else if (num === 1) {
-                self.decoration = "bold";
+                self.decorations.push("bold");
             } else if (num === 2) {
-                self.decoration = "dim";
+                self.decorations.push("dim");
             // Enable code 2 to get string
             } else if (num == 3) {
-                  self.decoration = "italic";
+                  self.decorations.push("italic");
             } else if (num == 4) {
-                self.decoration = "underline";
+                self.decorations.push("underline");
             } else if (num == 5) {
-                self.decoration = "blink";
+                self.decorations.push("blink");
             } else if (num === 7) {
-                self.decoration = "reverse";
+                self.decorations.push("reverse");
             } else if (num === 8) {
-                self.decoration = "hidden";
+                self.decorations.push("hidden");
             // Enable code 9 to get strikethrough
             } else if (num === 9) {
-                  self.decoration = "strikethrough";
+                  self.decorations.push("strikethrough");
             } else if (num == 39) {
                 self.fg = null;
             } else if (num == 49) {
@@ -454,7 +456,7 @@ class Anser {
             }
         }
 
-        if ((self.fg === null) && (self.bg === null) && (self.decoration === null)) {
+        if ((self.fg === null) && (self.bg === null) && (self.decorations.length === 0)) {
             return result;
         } else {
             let styles = [];
@@ -465,7 +467,8 @@ class Anser {
             result.bg = self.bg;
             result.fg_truecolor = self.fg_truecolor;
             result.bg_truecolor = self.bg_truecolor;
-            result.decoration = self.decoration;
+            result.decorations = self.decorations;
+            result.decoration = self.decorations.slice(-1).pop() || null;
             result.was_processed = true;
 
             return result;
@@ -488,8 +491,6 @@ class Anser {
      * @return {Object|String} The result (object if `json` is wanted back or string otherwise).
      */
     processChunk (text, options, markup) {
-
-        let self = this;
         options = options || {};
         let jsonChunk = this.processChunkJson(text, options, markup);
 
@@ -499,8 +500,10 @@ class Anser {
 
         let use_classes = options.use_classes;
 
-        let styles = [];
-        let classes = [];
+        let colors = [];
+        let decorations = [];
+        let textDecorations = [];
+
         let data = {};
         let render_data = data => {
             let fragments = [];
@@ -515,53 +518,57 @@ class Anser {
 
         if (jsonChunk.fg) {
             if (use_classes) {
-                classes.push(jsonChunk.fg + "-fg");
+                colors.push(jsonChunk.fg + "-fg");
                 if (jsonChunk.fg_truecolor !== null) {
                     data["ansi-truecolor-fg"] = jsonChunk.fg_truecolor;
                     jsonChunk.fg_truecolor = null;
                 }
             } else {
-                styles.push("color:rgb(" + jsonChunk.fg + ")");
+                colors.push("color:rgb(" + jsonChunk.fg + ")");
             }
         }
 
         if (jsonChunk.bg) {
             if (use_classes) {
-                classes.push(jsonChunk.bg + "-bg");
+                colors.push(jsonChunk.bg + "-bg");
                 if (jsonChunk.bg_truecolor !== null) {
                     data["ansi-truecolor-bg"] = jsonChunk.bg_truecolor;
                     jsonChunk.bg_truecolor = null;
                 }
             } else {
-              styles.push("background-color:rgb(" + jsonChunk.bg + ")");
+              colors.push("background-color:rgb(" + jsonChunk.bg + ")");
             }
         }
 
-        if (jsonChunk.decoration) {
+        jsonChunk.decorations.forEach((decoration) => {
             if (use_classes) {
-                classes.push("ansi-" + jsonChunk.decoration);
-            } else if (jsonChunk.decoration === "bold") {
-                styles.push("font-weight:bold");
-            } else if (jsonChunk.decoration === "dim") {
-                styles.push("opacity:0.5");
-            } else if (jsonChunk.decoration === "italic") {
-                styles.push("font-style:italic");
-            // underline and blink are treated bellow
-            } else if (jsonChunk.decoration === "reverse") {
-                styles.push("filter:invert(100%)");
-            } else if (jsonChunk.decoration === "hidden") {
-                styles.push("visibility:hidden");
-            } else if (jsonChunk.decoration === "strikethrough") {
-                styles.push("text-decoration:line-through");
+                decorations.push("ansi-" + decoration);
+            } else if (decoration === "bold") {
+                decorations.push("font-weight:bold");
+            } else if (decoration === "dim") {
+                decorations.push("opacity:0.5");
+            } else if (decoration === "italic") {
+                decorations.push("font-style:italic");
+              } else if (decoration === "reverse") {
+                decorations.push("filter:invert(100%)");
+            } else if (decoration === "hidden") {
+                decorations.push("visibility:hidden");
+            } else if (decoration === "strikethrough") {
+                textDecorations.push("line-through");
             } else {
-                styles.push("text-decoration:" + jsonChunk.decoration);
+                // underline and blink are treated here
+                textDecorations.push(decoration);
             }
+        });
+
+        if (textDecorations.length) {
+            decorations.push("text-decoration:" + textDecorations.join(" "));
         }
 
         if (use_classes) {
-            return "<span class=\"" + classes.join(" ") + "\"" + render_data(data) + ">" + jsonChunk.content + "</span>";
+            return "<span class=\"" + colors.concat(decorations).join(" ") + "\"" + render_data(data) + ">" + jsonChunk.content + "</span>";
         } else {
-            return "<span style=\"" + styles.join(";") + "\"" + render_data(data) + ">" + jsonChunk.content + "</span>";
+            return "<span style=\"" + colors.concat(decorations).join(";") + "\"" + render_data(data) + ">" + jsonChunk.content + "</span>";
         }
     }
 };

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -436,6 +436,25 @@ describe("Anser", () => {
             });
         });
 
+        describe("use multiple text styles", () => {
+            describe("default", () => {
+                it("underline, blinking, bold, blue text on red background", () => {
+                    const start = "\x1B[4m" + "\x1B[5m" + "\x1B[1;34m" + "\x1B[41m" + "foo" + "\x1B[0m" + "bar";
+                    const expected = '<span style="color:rgb(0, 0, 187);background-color:rgb(187, 0, 0);font-weight:bold;text-decoration:underline blink">foo</span>bar';
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+            });
+            describe("with classes", () => {
+                it("underline, blinking, bold, blue text on red background", () => {
+                    const start = "\x1B[4m" + "\x1B[5m" + "\x1B[1;34m" + "\x1B[41m" + "foo" + "\x1B[0m" + "bar";
+                    const expected = '<span class="ansi-blue-fg ansi-red-bg ansi-underline ansi-blink ansi-bold">foo</span>bar';
+                    const l = Anser.ansiToHtml(start, {use_classes: true});
+                    l.should.eql(expected);
+                });
+            });
+        });
+
         describe("ignore unsupported CSI", () => {
             it("should correctly convert a string similar to CSI", () => {
                 // https://github.com/drudru/Anser/pull/15

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -455,6 +455,49 @@ describe("Anser", () => {
             });
         });
 
+        describe("reverse/inverse colors", () => {
+            describe("default", () => {
+                it("blue text on red background, to red text on blue background", () => {
+                    const start = "\x1B[7m" + "\x1B[34m" + "\x1B[41m" + "foo" + "\x1B[0m";
+                    const expected = '<span style="color:rgb(187, 0, 0);background-color:rgb(0, 0, 187)" data-ansi-is-inverted="true">foo</span>';
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+                it("blue text inversed to be blue background", () => {
+                    const start = "\x1B[7m" + "\x1B[34m" + "foo" + "\x1B[0m";
+                    const expected = '<span style="color:rgb(0, 0, 0);background-color:rgb(0, 0, 187)" data-ansi-is-inverted="true">foo</span>';
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+                it("red background inversed to be red text", () => {
+                    const start = "\x1B[7m" + "\x1B[41m" + "foo" + "\x1B[0m";
+                    const expected = '<span style="color:rgb(187, 0, 0);background-color:rgb(255,255,255)" data-ansi-is-inverted="true">foo</span>';
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+            });
+            describe("with classes", () => {
+                it("blue text on red background, to red text on blue background", () => {
+                    const start = "\x1B[7m" + "\x1B[34m" + "\x1B[41m" + "foo" + "\x1B[0m";
+                    const expected = '<span class="ansi-red-fg ansi-blue-bg" data-ansi-is-inverted="true">foo</span>';
+                    const l = Anser.ansiToHtml(start, {use_classes: true});
+                    l.should.eql(expected);
+                });
+                it("blue text inversed to be blue background", () => {
+                    const start = "\x1B[7m" + "\x1B[34m" + "foo" + "\x1B[0m";
+                    const expected = '<span class="ansi-black-fg ansi-blue-bg" data-ansi-is-inverted="true">foo</span>';
+                    const l = Anser.ansiToHtml(start, {use_classes: true});
+                    l.should.eql(expected);
+                });
+                it("red background inversed to be red text", () => {
+                    const start = "\x1B[7m" + "\x1B[41m" + "foo" + "\x1B[0m";
+                    const expected = '<span class="ansi-red-fg ansi-white-bg" data-ansi-is-inverted="true">foo</span>';
+                    const l = Anser.ansiToHtml(start, {use_classes: true});
+                    l.should.eql(expected);
+                });
+            });
+        });
+
         describe("ignore unsupported CSI", () => {
             it("should correctly convert a string similar to CSI", () => {
                 // https://github.com/drudru/Anser/pull/15


### PR DESCRIPTION
I'm using Anser to build a client for the MUD game I play (yes, there are still people playing MUDs! 😄 ).
The problem is that Anser has very basic support for decorations and color reverse, and MUD games often heavily use these.

This PR makes two things:
- adds support for multiple decoration stacking until reset - this makes things like "red underlined text on yellow background and flashing" possible
- adds proper color reverse - ad the moment color reverse in Answer is done either by adding `ansi-reverse` class, or a `filter:invert(100%)` style. While the `ansi-reverse` can be somehow handled correctly with CSS, the `filter:invert(100%)` is totally wrong. As far as I know no Telnet client actually does a "negative" effect when using the "reverse/invert" ANSI code.
What client do is they **swap** background/foreground colors, not invert them.

**How multiple decorations are implemented:**
- the existing `decoration` in JSON output stays the same, and outputs the same value as before (in fact, last decoration found in the chunk) - this is to keep the changes backwards-compatible.
- a new `decorations` property is added to JSON object, this is an array of decorations found in the chunk, in the order of finding

Doing it like this it **will not** break any existing usage of the library.

**How inverting of colors is implemented:**
- if the "reverse/invert" ANSI code is found in the chunk, the foreground and background colors are swapped. This includes truecolor as well
- that operation is done before the moment where JSON is outputted, so it works in all modes of operation
- if `ansiToJson` is used the returned JSON contains new property `isInverted: boolean` which is just informational, in case that information is useful
- if `ansiToHtml` is used, the colors are obviously also swapped in the output, plus the `data-is-inversed="true"` is added t signal this
- the class `ansi-reverse` is no loger outputted
- if foreground or background color is missing in the chunk **and** inverting takes place, **these missing colors are defaulted** to either black (background) or white (foreground).

The telnet clients normally do it like that, so if Anser does not do it, it would lead to weird outputs. For example if you take a bright yellow text and invert it, the telnet client will show black text on bright yellow background. But the browser does not default the background to black, therefore after swapping colors, the foreground is not styled and displays as default font color (probably white).

By doing it like this it, in my opinion, it **should not** break existing usage of the library.
I think so because we are not sending `ansi-reverse` anymore, so will not trigger any "reversing" done in the app that uses Answer. Instead that app will simply get the colors inverted already, so wouldn't even know the reversing happened.
That's what the `isInverted` and `data-is-inverted` informations are for, so if that's important for the app to know, it will get that information. But the projects already using Anser, will likely work all fine by simply displaying colors as instructed by Answer output.

I think the only non-backward-compatible thing in this case is not outputting `filter:invert(100%)`, so if there's some app that's using Answer, and displays some inverted text, it will now appear differently (actually, it will now appear as it should look like in the real telnet client).

Here are some proofs that it works all fine.

This is a help page about using colors in the game I play, rendered with Answer (using classes, and my own CSS for colors):
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/5413271/91775741-19730900-ebec-11ea-83ef-c3e048528898.gif)

The same page with `telnet` in MacOS iTerm:
<img width="582" alt="Screenshot 2020-09-01 at 00 42 21" src="https://user-images.githubusercontent.com/5413271/91775772-33145080-ebec-11ea-829b-835249a1d5b5.png">

The same page in `zMud` on Windows:
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/5413271/91776406-99e63980-ebed-11ea-92fa-65e0b62f4ba7.gif)
