### PR TITLE
Add several widely used style codes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,7 @@ class Anser {
     constructor () {
         this.fg = this.bg = this.fg_truecolor = this.bg_truecolor = null;
         this.bright = 0;
+        this.decorations = [];
     }
 
     /**
@@ -360,8 +361,6 @@ class Anser {
 
         let self = this;
 
-        self.decorations = self.decorations || [];
-
         while (nums.length > 0) {
             let num_str = nums.shift();
             let num = parseInt(num_str);
@@ -374,11 +373,11 @@ class Anser {
             } else if (num === 2) {
                 self.decorations.push("dim");
             // Enable code 2 to get string
-            } else if (num == 3) {
+            } else if (num === 3) {
                   self.decorations.push("italic");
-            } else if (num == 4) {
+            } else if (num === 4) {
                 self.decorations.push("underline");
-            } else if (num == 5) {
+            } else if (num === 5) {
                 self.decorations.push("blink");
             } else if (num === 7) {
                 self.decorations.push("reverse");
@@ -386,10 +385,31 @@ class Anser {
                 self.decorations.push("hidden");
             // Enable code 9 to get strikethrough
             } else if (num === 9) {
-                  self.decorations.push("strikethrough");
-            } else if (num == 39) {
+                self.decorations.push("strikethrough");
+            /**
+             * Add several widely used style codes
+             * @see https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+             */
+            } else if (num === 21) {
+                self.removeDecoration("bold");
+            } else if (num === 22) {
+                self.removeDecoration("bold");
+                self.removeDecoration("dim");
+            } else if (num === 23) {
+                self.removeDecoration("italic");
+            } else if (num === 24) {
+                self.removeDecoration("underline");
+            } else if (num === 25) {
+                self.removeDecoration("blink");
+            } else if (num === 27) {
+                self.removeDecoration("reverse");
+            } else if (num === 28) {
+                self.removeDecoration("hidden");
+            } else if (num === 29) {
+                self.removeDecoration("strikethrough");
+            } else if (num === 39) {
                 self.fg = null;
-            } else if (num == 49) {
+            } else if (num === 49) {
                 self.bg = null;
             // Foreground color
             } else if ((num >= 30) && (num < 38)) {
@@ -573,7 +593,7 @@ class Anser {
                 decorations.push("ansi-" + decoration);
                 return;
             }
-            // use styles            
+            // use styles
             if (decoration === "bold") {
                 decorations.push("font-weight:bold");
             } else if (decoration === "dim") {
@@ -600,6 +620,14 @@ class Anser {
             return "<span style=\"" + colors.concat(decorations).join(";") + "\"" + render_data(data) + ">" + jsonChunk.content + "</span>";
         }
     }
-};
+
+    removeDecoration(decoration) {
+        const index = this.decorations.indexOf(decoration);
+
+        if (index >= 0) {
+            this.decorations.splice(index, 1);
+        }
+    }
+}
 
 module.exports = Anser;

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -498,6 +498,25 @@ describe("Anser", () => {
             });
         });
 
+        describe("reset text styles with specific codes", () => {
+            describe("default", () => {
+                it('Normal intensity', () => {
+                    const start = "\x1B[1m" + "\x1B[2m" + "foo" + "\x1B[22m" + "bar";
+                    const expected = '<span style="font-weight:bold;opacity:0.5">foo</span>bar';
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+            });
+            describe("with classes", () => {
+                it('Normal intensity', () => {
+                    const start = "\x1B[1m" + "\x1B[2m" + "foo" + "\x1B[22m" + "bar";
+                    const expected = '<span class="ansi-bold ansi-dim">foo</span>bar';
+                    const l = Anser.ansiToHtml(start, {use_classes: true});
+                    l.should.eql(expected);
+                });
+            });
+        });
+
         describe("ignore unsupported CSI", () => {
             it("should correctly convert a string similar to CSI", () => {
                 // https://github.com/drudru/Anser/pull/15


### PR DESCRIPTION
`chalk.dim('foo')` generates ANSI sequence like `'\x1B[2mfoo\x1B[22m'`, while code `22` is not supported to revert the dim style, which makes the continued content become dim, too.