### PR TITLE
Escape quotes in escapeForHtml

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -178,8 +178,9 @@ class Anser {
      * @returns {String} The escpaed HTML output.
      */
     escapeForHtml (txt) {
-        return txt.replace(/[&<>]/gm, str =>
+        return txt.replace(/[&<>\"]/gm, str =>
                            str == "&" ? "&amp;" :
+                               str == '"' ? "&quot;" :
                                str == "<" ? "&lt;" :
                                str == ">" ? "&gt;" : ""
                           );


### PR DESCRIPTION
This will fix issues linkifying escaped links with quotes inside them