### PR TITLE
Fix linkify to only match valid URI characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,8 @@ const ANSI_COLORS = [
       , { color: "255, 255, 255",  "class": "ansi-bright-white"   }
     ]
 ];
+// https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
+const linkRegex = /(https?:\/\/(?:[A-Za-z0-9#;/?:@=+$',_.!~*()[\]-]|&amp;|%[A-Fa-f0-9]{2})+)/gm;
 
 class Anser {
 
@@ -49,9 +51,7 @@ class Anser {
      * Adds the links in the HTML.
      *
      * This replaces any links in the text with anchor tags that display the
-     * link. The links should have at least one whitespace character
-     * surrounding it. Also, you should apply this after you have run
-     * `ansiToHtml` on the text.
+     * link. You should apply this after you have run `ansiToHtml` on the text.
      *
      * @name Anser.linkify
      * @function
@@ -196,7 +196,7 @@ class Anser {
      * @returns {String} The HTML output containing link elements.
      */
     linkify (txt) {
-        return txt.replace(/(https?:\/\/[^\s]+)/gm, str => `<a href="${str}">${str}</a>`);
+        return txt.replace(linkRegex, str => `<a href="${str}">${str}</a>`);
     }
 
     /**


### PR DESCRIPTION
Fixes #63

It handles the fact that `escapeForHtml` has already been called and matches `&amp;` separately.

I used the RFC (basically the last 5 rules) from:
https://datatracker.ietf.org/doc/html/rfc3986#appendix-A

I tested it with:
```
# "> should be excluded
"https://github.com/os-autoinst/openQA.git"
<https://github.com/os-autoinst/os-autoinst.git>
# () should be included
https://de.wikipedia.org/wiki/Queen_(Band)
# query strings should be included
https://github.com/os-autoinst/openQA?foo=1%20&bar=*2
```

I am not sure how to run the tests. If you give me a hint, I will try and add a test for this.