### PR TITLE
fix testcase for 'mixed characters'

### DIFF
--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -80,7 +80,7 @@ describe("Anser", () => {
         describe("mixed characters", () => {
             it("should escape a mix of characters that require escaping", () => {
                 const start = "<&>/\\'\"";
-                const expected = "&lt;&amp;&gt;/\\'\"";;
+                const expected = "&lt;&amp;&gt;/\\'&quot;";
                 const l = Anser.escapeForHtml(start);
                 l.should.eql(expected);
             });


### PR DESCRIPTION
The current `expected` value includes `\"` which is the pre-escape value that the function under test is supposed to convert into `&quot;` (which it does), so this test was failing, incorrectly.

BTW I noticed this while packaging anser for Debian, which I'm doing to satisfy a dependency of openQA. The debian package will be called `node-anser` because we have a convention of adding a `node-` prefix to such packages.

Hopefully you don't mind :-)

Cheers, Phil.