### PR TITLE
Fix grayscale palette colors returning undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ class Anser {
         // Index 232..255 : Grayscale
         let level = 8;
         for (let i = 0; i < 24; ++i, level += 10) {
-            this.PALETTE_COLORS.push(format(level, level, level));
+            this.PALETTE_COLORS.push(level + ", " + level + ", " + level);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     ],
     "thanks": "This project is highly based on [`ansi_up`](https://github.com/drudru/ansi_up), by [@drudru](https://github.com/drudru/). Thanks! :cake:"
   },
+  "contributors": [
+    "Mikołaj Kutryj <mikolaj.kutryj@gmail.com>"
+  ],
   "license": "MIT",
   "files": [
     "bin/",

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -237,6 +237,30 @@ describe("Anser", () => {
                     const l = Anser.ansiToHtml(start);
                     l.should.eql(expected);
                 });
+                it("grayscale, foreground (first: 232)", () => {
+                    const start = "\x1B[38;5;232m" + "gray" + "\x1B[0m";
+                    const expected = "<span style=\"color:rgb(8, 8, 8)\">gray</span>";
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+                it("grayscale, foreground (middle: 240)", () => {
+                    const start = "\x1B[38;5;240m" + "gray" + "\x1B[0m";
+                    const expected = "<span style=\"color:rgb(88, 88, 88)\">gray</span>";
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+                it("grayscale, foreground (last: 255)", () => {
+                    const start = "\x1B[38;5;255m" + "gray" + "\x1B[0m";
+                    const expected = "<span style=\"color:rgb(238, 238, 238)\">gray</span>";
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
+                it("grayscale, background", () => {
+                    const start = "\x1B[48;5;240m" + "gray" + "\x1B[0m";
+                    const expected = "<span style=\"background-color:rgb(88, 88, 88)\">gray</span>";
+                    const l = Anser.ansiToHtml(start);
+                    l.should.eql(expected);
+                });
             });
 
             describe("transform extend colors (true color)", () => {


### PR DESCRIPTION
The grayscale loop (ANSI 256-color codes 232-255) was incorrectly using the format() function which expects indices 0-5 into the levels array. Instead, it was passing actual RGB values (8, 18, 28, ..., 238) which are out of bounds, causing undefined values.

Fix by constructing the RGB string directly instead of using format().

This should resolve https://github.com/IonicaBizau/anser/issues/73